### PR TITLE
Fum 3217 align template for backend configs

### DIFF
--- a/deploy/infrastructure/main.tf
+++ b/deploy/infrastructure/main.tf
@@ -1,9 +1,9 @@
 locals {
-  namespace    = var.environment # must match the namespace in the ./deploy/application/main.tf 
-  service_name = "<APPLICATION_NAME>"
-  matching_index   = [for idx, name in data.aws_ssm_parameters_by_path.platform.names : idx if can(regex("^.*/cluster_name$", name))] 
-  first_index      = element(local.matching_index, 0)
-  cluster_name     = element(data.aws_ssm_parameters_by_path.platform.values, local.first_index)
+  namespace      = var.environment # must match the namespace in the ./deploy/application/main.tf 
+  service_name   = "<APPLICATION_NAME>"
+  matching_index = [for idx, name in data.aws_ssm_parameters_by_path.platform.names : idx if can(regex("^.*/cluster_name$", name))] 
+  first_index    = element(local.matching_index, 0)
+  cluster_name   = element(data.aws_ssm_parameters_by_path.platform.values, local.first_index)
 }
 
 resource "aws_ecr_repository" "this" {

--- a/deploy/infrastructure/providers.tf
+++ b/deploy/infrastructure/providers.tf
@@ -33,10 +33,3 @@ provider "aws" {
 
 data "aws_caller_identity" "current" {}
 
-data "terraform_remote_state" "infrastructure" {
-  backend = "s3"
-  config = {
-    bucket = "tf-state-${data.aws_caller_identity.current.account_id}"
-    key    = var.terraform_remote_state_key
-  }
-}


### PR DESCRIPTION
I had issue retrieving the cluster name through the infra remote state. We agreed on making it more dynamically for the cluster name retrieval in app deployment. It also makes sense to retrieve it in the same way in the infra stack.

This PR is adding the dynamic reading of SSM parameter for platform and removing any dependencies to external infrastructure state files.

Works together with https://github.com/DND-IT/tam-cli/pull/23
